### PR TITLE
ログインできるようにする

### DIFF
--- a/app/app.iml
+++ b/app/app.iml
@@ -74,6 +74,7 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/appcompat-v7/22.2.1/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/design/22.2.1/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-v4/22.2.1/jars" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/io.reactivex/rxandroid/1.0.1/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jacoco" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/javaResources" />
@@ -91,9 +92,15 @@
     </content>
     <orderEntry type="jdk" jdkName="Android API 22 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" exported="" name="gson-2.3.1" level="project" />
+    <orderEntry type="library" exported="" name="rxjava-1.0.13" level="project" />
     <orderEntry type="library" exported="" name="picasso-2.5.2" level="project" />
     <orderEntry type="library" exported="" name="support-v4-22.2.1" level="project" />
+    <orderEntry type="library" exported="" name="okhttp-2.4.0" level="project" />
     <orderEntry type="library" exported="" name="support-annotations-22.2.1" level="project" />
+    <orderEntry type="library" exported="" name="rxandroid-1.0.1" level="project" />
+    <orderEntry type="library" exported="" name="retrofit-1.9.0" level="project" />
+    <orderEntry type="library" exported="" name="okio-1.4.0" level="project" />
     <orderEntry type="library" exported="" name="design-22.2.1" level="project" />
     <orderEntry type="library" exported="" name="appcompat-v7-22.2.1" level="project" />
   </component>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,4 +24,7 @@ dependencies {
     compile 'com.android.support:design:22.2.1'
     compile 'com.android.support:appcompat-v7:22.2.1'
     compile 'com.squareup.picasso:picasso:2.5.2'
+    compile 'com.squareup.okhttp:okhttp:2.4.0'
+    compile 'com.squareup.retrofit:retrofit:1.9.0'
+    compile 'io.reactivex:rxandroid:1.0.1'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,9 @@
     <!-- To auto-complete the email text field in the login form with the user's emails -->
     <uses-permission android:name="android.permission.READ_PROFILE" />
     <uses-permission android:name="android.permission.READ_CONTACTS" />
+    <!-- To manage accounts in AccountManager -->
+    <uses-permission android:name="android.permission.GET_ACCOUNTS"/>
+    <uses-permission android:name="android.permission.AUTHENTICATE_ACCOUNTS"/>
 
     <application
         android:name=".JodoroidApplication"
@@ -38,6 +41,16 @@
             android:noHistory="true"
             android:windowSoftInputMode="adjustResize|stateVisible" >
         </activity>
+
+        <service android:name="com.pepabo.jodo.jodoroid.JodoAuthenticatorService" >
+            <intent-filter>
+                <action android:name="android.accounts.AccountAuthenticator" />
+            </intent-filter>
+
+            <meta-data
+                android:name="android.accounts.AccountAuthenticator"
+                android:resource="@xml/authenticator" />
+        </service>
     </application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,8 +18,7 @@
         android:theme="@style/AppTheme" >
         <activity
             android:name=".WelcomeActivity"
-            android:label="@string/app_name"
-            android:noHistory="true" >
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/pepabo/jodo/jodoroid/JodoAuthenticator.java
+++ b/app/src/main/java/com/pepabo/jodo/jodoroid/JodoAuthenticator.java
@@ -1,0 +1,69 @@
+package com.pepabo.jodo.jodoroid;
+
+import android.accounts.AbstractAccountAuthenticator;
+import android.accounts.Account;
+import android.accounts.AccountAuthenticatorResponse;
+import android.accounts.AccountManager;
+import android.accounts.NetworkErrorException;
+import android.content.Intent;
+import android.os.Bundle;
+
+public class JodoAuthenticator extends AbstractAccountAuthenticator {
+    public static final String ACCOUNT_TYPE = "com.pepabo.jodo";
+    public static final String ACCOUNT_TOKEN_TYPE = "com.pepabo.jodo.auth_token";
+
+    final JodoroidApplication mApp;
+
+    public JodoAuthenticator(JodoroidApplication app) {
+        super(app);
+        mApp = app;
+    }
+
+    @Override
+    public Bundle editProperties(AccountAuthenticatorResponse response, String accountType) {
+        return null;
+    }
+
+    @Override
+    public Bundle addAccount(AccountAuthenticatorResponse response, String accountType, String authTokenType, String[] requiredFeatures, Bundle options) throws NetworkErrorException {
+        final AccountManager accountManager = AccountManager.get(mApp);
+        final Account[] accounts = accountManager.getAccountsByType(JodoAuthenticator.ACCOUNT_TYPE);
+
+        if(accounts.length == 0) {
+            final Intent intent = new Intent(mApp, LoginActivity.class);
+            intent.putExtra(AccountManager.KEY_ACCOUNT_AUTHENTICATOR_RESPONSE, response);
+
+            final Bundle bundle = new Bundle();
+            bundle.putParcelable(AccountManager.KEY_INTENT, intent);
+            return bundle;
+        } else {
+            // TODO: Show message
+            return null;
+        }
+    }
+
+    @Override
+    public Bundle confirmCredentials(AccountAuthenticatorResponse response, Account account, Bundle options) throws NetworkErrorException {
+        return null;
+    }
+
+    @Override
+    public Bundle getAuthToken(AccountAuthenticatorResponse response, Account account, String authTokenType, Bundle options) throws NetworkErrorException {
+        return null;
+    }
+
+    @Override
+    public String getAuthTokenLabel(String authTokenType) {
+        return null;
+    }
+
+    @Override
+    public Bundle updateCredentials(AccountAuthenticatorResponse response, Account account, String authTokenType, Bundle options) throws NetworkErrorException {
+        return null;
+    }
+
+    @Override
+    public Bundle hasFeatures(AccountAuthenticatorResponse response, Account account, String[] features) throws NetworkErrorException {
+        return null;
+    }
+}

--- a/app/src/main/java/com/pepabo/jodo/jodoroid/JodoAuthenticatorService.java
+++ b/app/src/main/java/com/pepabo/jodo/jodoroid/JodoAuthenticatorService.java
@@ -1,0 +1,23 @@
+package com.pepabo.jodo.jodoroid;
+
+import android.app.Service;
+import android.content.Intent;
+import android.os.IBinder;
+import android.support.annotation.Nullable;
+
+public class JodoAuthenticatorService extends Service {
+    JodoAuthenticator mAuthenticator;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+
+        mAuthenticator = new JodoAuthenticator((JodoroidApplication) getApplication());
+    }
+
+    @Nullable
+    @Override
+    public IBinder onBind(Intent intent) {
+        return mAuthenticator.getIBinder();
+    }
+}

--- a/app/src/main/java/com/pepabo/jodo/jodoroid/JodoroidApplication.java
+++ b/app/src/main/java/com/pepabo/jodo/jodoroid/JodoroidApplication.java
@@ -5,17 +5,41 @@ import android.content.Context;
 
 import com.squareup.picasso.Picasso;
 
+
+import com.pepabo.jodo.jodoroid.models.APIService;
+import com.squareup.okhttp.OkHttpClient;
+
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.X509TrustManager;
+
+import retrofit.RestAdapter;
+import retrofit.android.AndroidLog;
+import retrofit.client.OkClient;
+
 public class JodoroidApplication extends Application {
+    APIService mService;
     Picasso mPicasso;
 
     @Override
     public void onCreate() {
         super.onCreate();
         mPicasso = createPicasso(getApplicationContext());
+        mService = createService();
     }
 
     public Picasso getPicasso() {
         return mPicasso;
+    }
+
+    public APIService getAPIService() {
+        return mService;
     }
 
     private static Picasso createPicasso(Context context) {
@@ -23,5 +47,51 @@ public class JodoroidApplication extends Application {
                 .loggingEnabled(true)
                 .indicatorsEnabled(BuildConfig.DEBUG)
                 .build();
+    }
+
+    private static APIService createService() {
+        try {
+            final SSLContext sslContext = SSLContext.getInstance("TLS");
+            sslContext.init(null, new X509TrustManager[]{new TrustEveryoneX509TrustManager()}, null);
+
+            final OkHttpClient client = new OkHttpClient();
+            client.setSslSocketFactory(sslContext.getSocketFactory()); // XXX
+            client.setHostnameVerifier(new NonVerifyingHostnameVerifier()); // XXX
+
+            final RestAdapter adapter = new RestAdapter.Builder()
+                    .setEndpoint("https://157.7.190.186/api/")
+                    .setClient(new OkClient(client))
+                    .setLogLevel(RestAdapter.LogLevel.FULL)
+                    .setLog(new AndroidLog("API"))
+                    .build();
+
+            return adapter.create(APIService.class);
+
+        } catch (NoSuchAlgorithmException | KeyManagementException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static class TrustEveryoneX509TrustManager implements X509TrustManager {
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+            throw new CertificateException();
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+        }
+
+        @Override
+        public X509Certificate[] getAcceptedIssuers() {
+            return new X509Certificate[0];
+        }
+    }
+
+    private static class NonVerifyingHostnameVerifier implements HostnameVerifier {
+        @Override
+        public boolean verify(String hostname, SSLSession session) {
+            return true;
+        }
     }
 }

--- a/app/src/main/java/com/pepabo/jodo/jodoroid/JodoroidApplication.java
+++ b/app/src/main/java/com/pepabo/jodo/jodoroid/JodoroidApplication.java
@@ -3,6 +3,9 @@ package com.pepabo.jodo.jodoroid;
 import android.app.Application;
 import android.content.Context;
 
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.squareup.picasso.Picasso;
 
 
@@ -24,6 +27,7 @@ import javax.net.ssl.X509TrustManager;
 import retrofit.RestAdapter;
 import retrofit.android.AndroidLog;
 import retrofit.client.OkClient;
+import retrofit.converter.GsonConverter;
 
 public class JodoroidApplication extends Application {
     public static final String ENDPOINT = "https://157.7.190.186/api/";
@@ -57,6 +61,12 @@ public class JodoroidApplication extends Application {
         return new CookieManager(); // TODO: Implement persistent cookie jar
     }
 
+    private static Gson createGson() {
+        return new GsonBuilder()
+                .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+                .create();
+    }
+
     private static APIService createAPIService() {
         try {
             final SSLContext sslContext = SSLContext.getInstance("TLS");
@@ -69,6 +79,7 @@ public class JodoroidApplication extends Application {
 
             final RestAdapter adapter = new RestAdapter.Builder()
                     .setEndpoint(ENDPOINT)
+                    .setConverter(new GsonConverter(createGson()))
                     .setClient(new OkClient(client))
                     .setLogLevel(RestAdapter.LogLevel.FULL)
                     .setLog(new AndroidLog("API"))

--- a/app/src/main/java/com/pepabo/jodo/jodoroid/JodoroidApplication.java
+++ b/app/src/main/java/com/pepabo/jodo/jodoroid/JodoroidApplication.java
@@ -9,6 +9,8 @@ import com.squareup.picasso.Picasso;
 import com.pepabo.jodo.jodoroid.models.APIService;
 import com.squareup.okhttp.OkHttpClient;
 
+import java.net.CookieHandler;
+import java.net.CookieManager;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
@@ -24,6 +26,8 @@ import retrofit.android.AndroidLog;
 import retrofit.client.OkClient;
 
 public class JodoroidApplication extends Application {
+    public static final String ENDPOINT = "https://157.7.190.186/api/";
+
     APIService mService;
     Picasso mPicasso;
 
@@ -31,7 +35,7 @@ public class JodoroidApplication extends Application {
     public void onCreate() {
         super.onCreate();
         mPicasso = createPicasso(getApplicationContext());
-        mService = createService();
+        mService = createAPIService();
     }
 
     public Picasso getPicasso() {
@@ -49,17 +53,22 @@ public class JodoroidApplication extends Application {
                 .build();
     }
 
-    private static APIService createService() {
+    private static CookieHandler createCookieHandler() {
+        return new CookieManager(); // TODO: Implement persistent cookie jar
+    }
+
+    private static APIService createAPIService() {
         try {
             final SSLContext sslContext = SSLContext.getInstance("TLS");
             sslContext.init(null, new X509TrustManager[]{new TrustEveryoneX509TrustManager()}, null);
 
             final OkHttpClient client = new OkHttpClient();
+            client.setCookieHandler(createCookieHandler());
             client.setSslSocketFactory(sslContext.getSocketFactory()); // XXX
             client.setHostnameVerifier(new NonVerifyingHostnameVerifier()); // XXX
 
             final RestAdapter adapter = new RestAdapter.Builder()
-                    .setEndpoint("https://157.7.190.186/api/")
+                    .setEndpoint(ENDPOINT)
                     .setClient(new OkClient(client))
                     .setLogLevel(RestAdapter.LogLevel.FULL)
                     .setLog(new AndroidLog("API"))
@@ -80,6 +89,7 @@ public class JodoroidApplication extends Application {
 
         @Override
         public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+            // Trust any certificate!!!
         }
 
         @Override

--- a/app/src/main/java/com/pepabo/jodo/jodoroid/LoginActivity.java
+++ b/app/src/main/java/com/pepabo/jodo/jodoroid/LoginActivity.java
@@ -1,5 +1,8 @@
 package com.pepabo.jodo.jodoroid;
 
+import android.accounts.Account;
+import android.accounts.AccountAuthenticatorResponse;
+import android.accounts.AccountManager;
 import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
 import android.annotation.TargetApi;
@@ -10,7 +13,6 @@ import android.content.Intent;
 import android.content.Loader;
 import android.database.Cursor;
 import android.net.Uri;
-import android.os.AsyncTask;
 
 import android.os.Build;
 import android.os.Bundle;
@@ -26,25 +28,24 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
 
+import com.pepabo.jodo.jodoroid.models.Session;
+
 import java.util.ArrayList;
 import java.util.List;
+
+import rx.Observer;
+import rx.Subscription;
+import rx.android.schedulers.AndroidSchedulers;
+import rx.schedulers.Schedulers;
 
 /**
  * A login screen that offers login via email/password.
  */
 public class LoginActivity extends Activity implements LoaderCallbacks<Cursor> {
-
-    /**
-     * A dummy authentication store containing known user names and passwords.
-     * TODO: remove after connecting to a real authentication system.
-     */
-    private static final String[] DUMMY_CREDENTIALS = new String[]{
-            "foo@example.com:hello", "bar@example.com:world"
-    };
     /**
      * Keep track of the login task to ensure we can cancel it if requested.
      */
-    private UserLoginTask mAuthTask = null;
+    private Subscription mAuthTask = null;
 
     // UI references.
     private AutoCompleteTextView mEmailView;
@@ -96,7 +97,7 @@ public class LoginActivity extends Activity implements LoaderCallbacks<Cursor> {
      * errors are presented and no actual login attempt is made.
      */
     public void attemptLogin() {
-        if (mAuthTask != null) {
+        if (mAuthTask != null && !mAuthTask.isUnsubscribed()) {
             return;
         }
 
@@ -105,8 +106,8 @@ public class LoginActivity extends Activity implements LoaderCallbacks<Cursor> {
         mPasswordView.setError(null);
 
         // Store values at the time of the login attempt.
-        String email = mEmailView.getText().toString();
-        String password = mPasswordView.getText().toString();
+        final String email = mEmailView.getText().toString();
+        final String password = mPasswordView.getText().toString();
 
         boolean cancel = false;
         View focusView = null;
@@ -137,8 +138,36 @@ public class LoginActivity extends Activity implements LoaderCallbacks<Cursor> {
             // Show a progress spinner, and kick off a background task to
             // perform the user login attempt.
             showProgress(true);
-            mAuthTask = new UserLoginTask(email, password);
-            mAuthTask.execute((Void) null);
+
+            mAuthTask = ((JodoroidApplication) getApplication()).getAPIService()
+                    .login(email, password)
+                    .observeOn(AndroidSchedulers.mainThread())
+                    .subscribe(new Observer<Session>() {
+                        @Override
+                        public void onCompleted() {
+                        }
+
+                        @Override
+                        public void onError(Throwable e) {
+                            showProgress(false);
+                            mPasswordView.setError(getString(R.string.error_incorrect_password));
+                            mPasswordView.requestFocus();
+                            mAuthTask.unsubscribe();
+                        }
+
+                        @Override
+                        public void onNext(Session session) {
+                            if(session != null && session.getAuthToken() != null) {
+                                final Account account = new Account(email, JodoAuthenticator.ACCOUNT_TYPE);
+                                final AccountManager accountManager = AccountManager.get(getApplicationContext());
+                                accountManager.addAccountExplicitly(account, null, null);
+                                accountManager.setAuthToken(account, JodoAuthenticator.ACCOUNT_TOKEN_TYPE, session.getAuthToken());
+
+                                setResult(RESULT_OK);
+                                finish();
+                            }
+                        }
+                    });
         }
     }
 
@@ -229,7 +258,6 @@ public class LoginActivity extends Activity implements LoaderCallbacks<Cursor> {
         };
 
         int ADDRESS = 0;
-        int IS_PRIMARY = 1;
     }
 
 
@@ -240,65 +268,6 @@ public class LoginActivity extends Activity implements LoaderCallbacks<Cursor> {
                         android.R.layout.simple_dropdown_item_1line, emailAddressCollection);
 
         mEmailView.setAdapter(adapter);
-    }
-
-    /**
-     * Represents an asynchronous login/registration task used to authenticate
-     * the user.
-     */
-    public class UserLoginTask extends AsyncTask<Void, Void, Boolean> {
-
-        private final String mEmail;
-        private final String mPassword;
-
-        UserLoginTask(String email, String password) {
-            mEmail = email;
-            mPassword = password;
-        }
-
-        @Override
-        protected Boolean doInBackground(Void... params) {
-            // TODO: attempt authentication against a network service.
-
-            try {
-                // Simulate network access.
-                Thread.sleep(2000);
-            } catch (InterruptedException e) {
-                return false;
-            }
-
-            for (String credential : DUMMY_CREDENTIALS) {
-                String[] pieces = credential.split(":");
-                if (pieces[0].equals(mEmail)) {
-                    // Account exists, return true if the password matches.
-                    return pieces[1].equals(mPassword);
-                }
-            }
-
-            // TODO: register the new account here.
-            return true;
-        }
-
-        @Override
-        protected void onPostExecute(final Boolean success) {
-            mAuthTask = null;
-
-            if (success) {
-                Intent intent = new Intent(getApplicationContext(), MainActivity.class);
-                startActivity(intent);
-                finish();
-            } else {
-                showProgress(false);
-                mPasswordView.setError(getString(R.string.error_incorrect_password));
-                mPasswordView.requestFocus();
-            }
-        }
-
-        @Override
-        protected void onCancelled() {
-            mAuthTask = null;
-            showProgress(false);
-        }
     }
 }
 

--- a/app/src/main/java/com/pepabo/jodo/jodoroid/WelcomeActivity.java
+++ b/app/src/main/java/com/pepabo/jodo/jodoroid/WelcomeActivity.java
@@ -1,15 +1,50 @@
 package com.pepabo.jodo.jodoroid;
 
+import android.accounts.Account;
+import android.accounts.AccountManager;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 
+import java.util.List;
+
 public class WelcomeActivity extends Activity {
+    private static final int REQUEST_LOGIN = 100;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
+        final AccountManager accountManager = AccountManager.get(getApplicationContext());
+        final Account[] accounts = accountManager.getAccountsByType(JodoAuthenticator.ACCOUNT_TYPE);
+
+        if(accounts.length == 0) {
+            startLoginActivity();
+        } else {
+            startMainActivity();
+            finish();
+        }
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        if(requestCode == REQUEST_LOGIN) {
+            if(resultCode == RESULT_OK) {
+                startMainActivity();
+            }
+        } else {
+            super.onActivityResult(requestCode, resultCode, data);
+        }
+        finish();
+    }
+
+    private void startLoginActivity() {
         Intent intent = new Intent(getApplicationContext(), LoginActivity.class);
+        startActivityForResult(intent, REQUEST_LOGIN);
+    }
+
+    private void startMainActivity() {
+        Intent intent = new Intent(getApplicationContext(), MainActivity.class);
         startActivity(intent);
     }
 }

--- a/app/src/main/java/com/pepabo/jodo/jodoroid/models/APIService.java
+++ b/app/src/main/java/com/pepabo/jodo/jodoroid/models/APIService.java
@@ -1,0 +1,23 @@
+package com.pepabo.jodo.jodoroid.models;
+
+import java.util.List;
+
+import retrofit.http.DELETE;
+import retrofit.http.Field;
+import retrofit.http.FormUrlEncoded;
+import retrofit.http.GET;
+import retrofit.http.POST;
+import rx.Observable;
+
+public interface APIService {
+    @POST("/login")
+    @FormUrlEncoded
+    Observable<Void> login(@Field("session[email]") String email,
+                           @Field("session[password]") String password);
+
+    @DELETE("/logout")
+    Observable<Void> logout();
+
+    @GET("/feed")
+    Observable<List<Micropost>> fetchFeed();
+}

--- a/app/src/main/java/com/pepabo/jodo/jodoroid/models/APIService.java
+++ b/app/src/main/java/com/pepabo/jodo/jodoroid/models/APIService.java
@@ -12,7 +12,7 @@ import rx.Observable;
 public interface APIService {
     @POST("/login")
     @FormUrlEncoded
-    Observable<Void> login(@Field("session[email]") String email,
+    Observable<Session> login(@Field("session[email]") String email,
                            @Field("session[password]") String password);
 
     @DELETE("/logout")

--- a/app/src/main/java/com/pepabo/jodo/jodoroid/models/Session.java
+++ b/app/src/main/java/com/pepabo/jodo/jodoroid/models/Session.java
@@ -1,0 +1,12 @@
+package com.pepabo.jodo.jodoroid.models;
+
+public class Session {
+    private String authToken;
+
+    public Session() {
+    }
+
+    public String getAuthToken() {
+        return authToken;
+    }
+}

--- a/app/src/main/res/xml/authenticator.xml
+++ b/app/src/main/res/xml/authenticator.xml
@@ -1,0 +1,5 @@
+<account-authenticator xmlns:android="http://schemas.android.com/apk/res/android"
+    android:accountType="com.pepabo.jodo"
+    android:icon="@mipmap/ic_launcher"
+    android:label="@string/app_name"
+    android:smallIcon="@mipmap/ic_launcher" />


### PR DESCRIPTION
このPRでは，WebAPIサーバと通信をして実際にログインを行えるようにします．

追加した機能:
- ログイン画面でボタンを押すと実際にAPIサーバと通信を行って，認証トークンを取得する
- AndroidのAccountManagerを使って，ユーザのメールアドレスと認証トークンを保存する
- 起動時にすでにアカウントが保存されている場合，ログイン画面をスキップしてホーム画面に遷移する
