### PR TITLE
オープンソース・ライセンスを表示するダイアログを追加

### DIFF
--- a/app/app.iml
+++ b/app/app.iml
@@ -74,6 +74,7 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/appcompat-v7/22.2.1/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/design/22.2.1/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-v4/22.2.1/jars" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/de.psdev.licensesdialog/licensesdialog/1.8.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/io.reactivex/rxandroid/1.0.1/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jacoco" />
@@ -93,15 +94,17 @@
     <orderEntry type="jdk" jdkName="Android API 22 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" exported="" name="gson-2.3.1" level="project" />
-    <orderEntry type="library" exported="" name="rxjava-1.0.13" level="project" />
     <orderEntry type="library" exported="" name="picasso-2.5.2" level="project" />
     <orderEntry type="library" exported="" name="support-v4-22.2.1" level="project" />
+    <orderEntry type="library" exported="" name="licensesdialog-1.8.0" level="project" />
     <orderEntry type="library" exported="" name="okhttp-2.4.0" level="project" />
     <orderEntry type="library" exported="" name="support-annotations-22.2.1" level="project" />
+    <orderEntry type="library" exported="" name="jsr305-3.0.0" level="project" />
     <orderEntry type="library" exported="" name="rxandroid-1.0.1" level="project" />
     <orderEntry type="library" exported="" name="retrofit-1.9.0" level="project" />
+    <orderEntry type="library" exported="" name="appcompat-v7-22.2.1" level="project" />
+    <orderEntry type="library" exported="" name="rxjava-1.0.13" level="project" />
     <orderEntry type="library" exported="" name="okio-1.4.0" level="project" />
     <orderEntry type="library" exported="" name="design-22.2.1" level="project" />
-    <orderEntry type="library" exported="" name="appcompat-v7-22.2.1" level="project" />
   </component>
 </module>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,4 +27,5 @@ dependencies {
     compile 'com.squareup.okhttp:okhttp:2.4.0'
     compile 'com.squareup.retrofit:retrofit:1.9.0'
     compile 'io.reactivex:rxandroid:1.0.1'
+    compile 'de.psdev.licensesdialog:licensesdialog:1.8.0'
 }

--- a/app/src/main/java/com/pepabo/jodo/jodoroid/MainActivity.java
+++ b/app/src/main/java/com/pepabo/jodo/jodoroid/MainActivity.java
@@ -16,6 +16,8 @@ import android.content.Intent;
 import com.pepabo.jodo.jodoroid.models.Micropost;
 import com.pepabo.jodo.jodoroid.models.User;
 
+import de.psdev.licensesdialog.LicensesDialog;
+
 public class MainActivity extends AppCompatActivity
         implements
         NavigationView.OnNavigationItemSelectedListener,
@@ -26,6 +28,7 @@ public class MainActivity extends AppCompatActivity
     public static final String ACTION_VIEW_ALL_USERS = "com.pepabo.jodo.jodoroid.VIEW_ALL_USERS";
     public static final String ACTION_VIEW_FOLLOWERS = "com.pepabo.jodo.jodoroid.VIEW_FOLLOWERS";
     public static final String ACTION_VIEW_FOLLOWING = "com.pepabo.jodo.jodoroid.VIEW_FOLLOWING";
+    public static final String ACTION_VIEW_LICENSES = "com.pepabo.jodo.jodoroid.VIEW_LICENSES";
     public static final String EXTRA_USER_ID = "userId";
 
     private ActionBarDrawerToggle mDrawerToggle;
@@ -112,6 +115,9 @@ public class MainActivity extends AppCompatActivity
             case ACTION_VIEW_FOLLOWING:
                 showFollowing(getUserIdFromIntent(intent));
                 return true;
+            case ACTION_VIEW_LICENSES:
+                showLicenses();
+                return true;
         }
         return false;
     }
@@ -132,6 +138,13 @@ public class MainActivity extends AppCompatActivity
     private void showFollowing(long userId) {
         showFragment(UserFollowersFragment
                 .newInstance(userId, UserFollowersFragment.TYPE_FOLLOWING));
+    }
+
+    private void showLicenses() {
+        new LicensesDialog.Builder(this)
+                .setNotices(R.raw.notices)
+                .build()
+                .show();
     }
 
     private void showFragment(Fragment fragment) {
@@ -162,6 +175,11 @@ public class MainActivity extends AppCompatActivity
                 intent = new Intent(getApplicationContext(), MainActivity.class);
                 intent.setAction(ACTION_VIEW_ALL_USERS);
                 break;
+            case R.id.action_view_oss_license:
+                intent = new Intent(getApplicationContext(), MainActivity.class);
+                intent.setAction(ACTION_VIEW_LICENSES);
+                break;
+
         }
 
         if (intent != null) {

--- a/app/src/main/res/menu/navigation_menu.xml
+++ b/app/src/main/res/menu/navigation_menu.xml
@@ -6,4 +6,7 @@
     <item
         android:id="@+id/action_view_all_users"
         android:title="@string/title_section_all_users" />
+    <item
+        android:id="@+id/action_view_oss_license"
+        android:title="@string/title_section_oss_license" />
 </menu>

--- a/app/src/main/res/raw/notices.xml
+++ b/app/src/main/res/raw/notices.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<notices>
+    <notice>
+        <name>LicensesDialog</name>
+        <url>https://psdev.de/LicensesDialog/</url>
+        <copyright>Copyright 2013 Philip Schiffer</copyright>
+        <license>Apache Software License 2.0</license>
+    </notice>
+</notices>

--- a/app/src/main/res/raw/notices.xml
+++ b/app/src/main/res/raw/notices.xml
@@ -1,9 +1,60 @@
 <?xml version="1.0" encoding="utf-8"?>
 <notices>
     <notice>
+        <name>Android Support Library</name>
+        <url>https://source.android.com/</url>
+        <copyright>Copyright (c) 2005-2013, The Android Open Source Project</copyright>
+        <license>Apache Software License 2.0</license>
+    </notice>
+    <notice>
+        <name>OkHttp</name>
+        <url>https://square.github.io/okhttp/</url>
+        <copyright>Copyright 2014 Square, Inc.</copyright>
+        <license>Apache Software License 2.0</license>
+    </notice>
+    <notice>
+        <name>Picasso</name>
+        <url>https://square.github.io/picasso/</url>
+        <copyright>Copyright 2013 Square, Inc.</copyright>
+        <license>Apache Software License 2.0</license>
+    </notice>
+    <notice>
+        <name>Retrofit</name>
+        <url>https://square.github.io/retrofit/</url>
+        <copyright>Copyright 2013 Square, Inc.</copyright>
+        <license>Apache Software License 2.0</license>
+    </notice>
+    <notice>
+        <name>Okio</name>
+        <url>https://square.github.io/okio/</url>
+        <license>Apache Software License 2.0</license>
+    </notice>
+    <notice>
+        <name>RxAndroid</name>
+        <url>https://github.com/ReactiveX/RxAndroid</url>
+        <license>Apache Software License 2.0</license>
+    </notice>
+    <notice>
+        <name>RxJava</name>
+        <url>https://github.com/ReactiveX/RxJava</url>
+        <copyright>Copyright 2013 Netflix, Inc.</copyright>
+        <license>Apache Software License 2.0</license>
+    </notice>
+    <notice>
+        <name>Gson</name>
+        <url>https://github.com/google/gson</url>
+        <copyright>Copyright 2008 Google Inc.</copyright>
+        <license>Apache Software License 2.0</license>
+    </notice>
+    <notice>
         <name>LicensesDialog</name>
         <url>https://psdev.de/LicensesDialog/</url>
         <copyright>Copyright 2013 Philip Schiffer</copyright>
+        <license>Apache Software License 2.0</license>
+    </notice>
+    <notice>
+        <name>FindBugs-jsr305</name>
+        <url>https://code.google.com/p/findbugs/</url>
         <license>Apache Software License 2.0</license>
     </notice>
 </notices>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,4 +19,5 @@
 
     <string name="hello_world">Hello world!</string>
 
+    <string name="title_section_oss_license">Open source licenses</string>
 </resources>


### PR DESCRIPTION
利用しているライブラリのライセンスを表示するようにしました．
とりあえず，drawerの一番下にメニューを増やしています．

リンクされているライブラリはひととおりライセンスを調べて書きましたが，不足/誤りがあれば教えて下さい．

![device-2015-08-26-183727](https://cloud.githubusercontent.com/assets/1135690/9490242/92d1f434-4c21-11e5-9ac7-12818fc7ec57.png)
![device-2015-08-26-183715](https://cloud.githubusercontent.com/assets/1135690/9490236/8b14cec4-4c21-11e5-9689-cb67b4c63735.png)
