### PR TITLE
マイクロポストの削除

### DIFF
--- a/app/src/main/java/com/pepabo/jodo/jodoroid/MicropostListFragment.java
+++ b/app/src/main/java/com/pepabo/jodo/jodoroid/MicropostListFragment.java
@@ -1,19 +1,22 @@
 package com.pepabo.jodo.jodoroid;
 
-import android.content.Intent;
 import android.content.DialogInterface;
+import android.content.Intent;
 import android.support.v7.app.AlertDialog;
-import android.util.Log;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.ListView;
+import android.widget.Toast;
 
 import com.pepabo.jodo.jodoroid.models.Micropost;
 import com.squareup.picasso.Picasso;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import rx.Observer;
+import rx.android.schedulers.AndroidSchedulers;
 
 /**
  * A fragment representing a list of Items.
@@ -37,24 +40,20 @@ public class MicropostListFragment extends SwipeRefreshListFragment {
         this.getListView().setOnItemLongClickListener(new AdapterView.OnItemLongClickListener() {
             @Override
             public boolean onItemLongClick(AdapterView<?> parent, View view, int position, long id) {
-                Log.e("EEE", "Long Clicked");
-
-                Micropost m = (Micropost) parent.getItemAtPosition(position);
+                final Micropost m = (Micropost) parent.getItemAtPosition(position);
                 long ownerId = m.getUser().getId();
-                
-                new AlertDialog.Builder(getActivity())
-                        .setTitle(R.string.title_delete_micropost)
-                        .setMessage(R.string.description_delete_micropost)
-                        .setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface dialog, int which) {
-                                Log.e("EEE", "DELETE !!!");
-                            }
-                        })
-                        .setNegativeButton(R.string.cancel, null)
-                        .show();
-                Log.e("EEE", m.getContent());
-                return true;
+
+                if (JodoAccounts.isMe(getActivity().getApplicationContext(), ownerId)) {
+                    new AlertDialog.Builder(getActivity())
+                            .setTitle(R.string.title_delete_micropost)
+                            .setMessage(R.string.description_delete_micropost)
+                            .setPositiveButton(R.string.ok, new PositiveButtonClickListener(m))
+                            .setNegativeButton(R.string.cancel, null)
+                            .show();
+                    return true;
+                } else {
+                    return false;
+                }
             }
         });
     }
@@ -83,6 +82,45 @@ public class MicropostListFragment extends SwipeRefreshListFragment {
             intent.setAction(MainActivity.ACTION_VIEW_USER_PROFILE);
             intent.putExtra(MainActivity.EXTRA_USER_ID, micropost.getUser().getId());
             startActivity(intent);
+        }
+    }
+
+    private class PositiveButtonClickListener implements DialogInterface.OnClickListener {
+        private Micropost mMicropost;
+
+        PositiveButtonClickListener(Micropost m) {
+            mMicropost = m;
+        }
+
+        @Override
+        public void onClick(DialogInterface dialog, int which) {
+            ((JodoroidApplication) getActivity().getApplication()).getAPIService()
+                    .deleteMicropost(mMicropost.getId())
+                    .observeOn(AndroidSchedulers.mainThread())
+                    .subscribe(new Observer<Void>() {
+
+                        @Override
+                        public void onCompleted() {
+                        }
+
+                        @Override
+                        public void onError(Throwable e) {
+                            Toast.makeText(
+                                    getActivity(),
+                                    R.string.toast_deletion_failed,
+                                    Toast.LENGTH_LONG
+                            ).show();
+                        }
+
+                        @Override
+                        public void onNext(Void v) {
+                            Toast.makeText(
+                                    getActivity(),
+                                    R.string.toast_deletion_succeed,
+                                    Toast.LENGTH_LONG
+                            ).show();
+                        }
+                    });
         }
     }
 }

--- a/app/src/main/java/com/pepabo/jodo/jodoroid/MicropostListFragment.java
+++ b/app/src/main/java/com/pepabo/jodo/jodoroid/MicropostListFragment.java
@@ -1,7 +1,11 @@
 package com.pepabo.jodo.jodoroid;
 
 import android.content.Intent;
+import android.content.DialogInterface;
+import android.support.v7.app.AlertDialog;
+import android.util.Log;
 import android.view.View;
+import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.ListView;
 
@@ -24,6 +28,35 @@ public class MicropostListFragment extends SwipeRefreshListFragment {
      * fragment (e.g. upon screen orientation changes).
      */
     public MicropostListFragment() {
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+
+        this.getListView().setOnItemLongClickListener(new AdapterView.OnItemLongClickListener() {
+            @Override
+            public boolean onItemLongClick(AdapterView<?> parent, View view, int position, long id) {
+                Log.e("EEE", "Long Clicked");
+
+                Micropost m = (Micropost) parent.getItemAtPosition(position);
+                long ownerId = m.getUser().getId();
+                
+                new AlertDialog.Builder(getActivity())
+                        .setTitle(R.string.title_delete_micropost)
+                        .setMessage(R.string.description_delete_micropost)
+                        .setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                Log.e("EEE", "DELETE !!!");
+                            }
+                        })
+                        .setNegativeButton(R.string.cancel, null)
+                        .show();
+                Log.e("EEE", m.getContent());
+                return true;
+            }
+        });
     }
 
     protected void setMicroposts(List<Micropost> microposts) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,9 @@
 <resources>
     <string name="app_name">Jodoroid</string>
 
+    <string name="ok">OK</string>
+    <string name="cancel">Cancel</string>
+
     <string name="title_section_home">Home</string>
     <string name="title_section_all_users">All users</string>
 
@@ -34,4 +37,7 @@
     <string name="action_send">Send</string>
     <string name="description_attached_image">Attached Image</string>
     <string name="description_user_avatar">User avatar</string>
+
+    <string name="title_delete_micropost">Delete This Post</string>
+    <string name="description_delete_micropost">Are You Sure?</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,4 +40,6 @@
 
     <string name="title_delete_micropost">Delete This Post</string>
     <string name="description_delete_micropost">Are You Sure?</string>
+    <string name="toast_deletion_succeed">Deleted Successfully.</string>
+    <string name="toast_deletion_failed">Deletion failed.</string>
 </resources>


### PR DESCRIPTION
LongClickすると出てくるダイアログから、自分のマイクロポストを削除できるようにしました。

<img width="355" alt="2015-09-02 18 40 40" src="https://cloud.githubusercontent.com/assets/2364702/9627878/279172f4-51a2-11e5-9178-fc3bf872a245.png">

`JodoAccounts.isMe(context, userId)`ってのをつくったのですが、自分のアカウントかを確かめる度にこの、`Account`と`AccountManager`引っ張ってくる処理するの効率悪い感があるのですが、どうでしょう。
