### PR TITLE
パスワードが短いときのエラーメッセージが間違っている

### DIFF
--- a/app/src/main/java/com/pepabo/jodo/jodoroid/PasswordValidator.java
+++ b/app/src/main/java/com/pepabo/jodo/jodoroid/PasswordValidator.java
@@ -14,7 +14,7 @@ public class PasswordValidator extends FormItemValidator {
         if (TextUtils.isEmpty(password)) {
             mError = mContext.getString(R.string.error_field_required);
         } else if (password.length() < 6) {
-            mError = mContext.getString(R.string.error_invalid_email);
+            mError = mContext.getString(R.string.error_invalid_password);
         }
     }
 }


### PR DESCRIPTION
短いパスワードを入力すると「メールアドレスがおかしい」って出る
