### PR TITLE
アカウントが削除された際に，ログイン画面へ戻すようにする

### DIFF
--- a/app/src/main/java/com/pepabo/jodo/jodoroid/MainActivity.java
+++ b/app/src/main/java/com/pepabo/jodo/jodoroid/MainActivity.java
@@ -2,6 +2,8 @@ package com.pepabo.jodo.jodoroid;
 
 import android.app.Fragment;
 import android.app.FragmentManager;
+import android.content.BroadcastReceiver;
+import android.content.Context;
 import android.content.res.Configuration;
 import android.support.design.widget.NavigationView;
 import android.support.v7.app.ActionBarDrawerToggle;
@@ -58,6 +60,8 @@ public class MainActivity extends AppCompatActivity
     @Bind(R.id.drawer_avatar)
     ImageView mDrawerAvatar;
 
+    BroadcastReceiver mLogoutReceiver;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -101,12 +105,20 @@ public class MainActivity extends AppCompatActivity
                     }
                 });
 
+        registerReceiver(mLogoutReceiver = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                finish();
+            }
+        }, JodoroidApplication.createLoggedOutIntentFilter());
+
         processIntent(getIntent());
     }
 
     @Override
     protected void onDestroy() {
         ButterKnife.unbind(this);
+        unregisterReceiver(mLogoutReceiver);
         super.onDestroy();
 
         if (mAccountSubscription != null) {

--- a/app/src/main/java/com/pepabo/jodo/jodoroid/PasswordChangeActivity.java
+++ b/app/src/main/java/com/pepabo/jodo/jodoroid/PasswordChangeActivity.java
@@ -1,5 +1,8 @@
 package com.pepabo.jodo.jodoroid;
 
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v7.app.ActionBar;
@@ -30,6 +33,8 @@ public class PasswordChangeActivity extends AppCompatActivity implements Passwor
     @Bind(R.id.progress)
     View mProgressView;
 
+    BroadcastReceiver mLogoutReceiver;
+
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -45,11 +50,19 @@ public class PasswordChangeActivity extends AppCompatActivity implements Passwor
         mAPIService = ((JodoroidApplication) getApplication()).getAPIService();
         mPresenter = new PasswordChangePresenter(getApplicationContext(), mAPIService);
         mPresenter.setView(this);
+
+        registerReceiver(mLogoutReceiver = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                finish();
+            }
+        }, JodoroidApplication.createLoggedOutIntentFilter());
     }
 
     @Override
     protected void onDestroy() {
         mPresenter.setView(null);
+        unregisterReceiver(mLogoutReceiver);
         super.onDestroy();
     }
 

--- a/app/src/main/java/com/pepabo/jodo/jodoroid/PostMicropost.java
+++ b/app/src/main/java/com/pepabo/jodo/jodoroid/PostMicropost.java
@@ -3,6 +3,8 @@ package com.pepabo.jodo.jodoroid;
 import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
 import android.annotation.TargetApi;
+import android.content.BroadcastReceiver;
+import android.content.Context;
 import android.content.Intent;
 import android.database.Cursor;
 import android.graphics.Bitmap;
@@ -37,6 +39,8 @@ public class PostMicropost extends AppCompatActivity {
     private View mPostformView;
     private View mProgressView;
 
+    BroadcastReceiver mLoggoutReceiver;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -50,6 +54,19 @@ public class PostMicropost extends AppCompatActivity {
         
         mPostformView = findViewById(R.id.post_form);
         mProgressView = findViewById(R.id.post_progress);
+
+        registerReceiver(mLoggoutReceiver = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                finish();
+            }
+        }, JodoroidApplication.createLoggedOutIntentFilter());
+    }
+
+    @Override
+    protected void onDestroy() {
+        unregisterReceiver(mLoggoutReceiver);
+        super.onDestroy();
     }
 
     @Override

--- a/app/src/main/java/com/pepabo/jodo/jodoroid/ProfileEditActivity.java
+++ b/app/src/main/java/com/pepabo/jodo/jodoroid/ProfileEditActivity.java
@@ -1,5 +1,8 @@
 package com.pepabo.jodo.jodoroid;
 
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v7.app.ActionBar;
@@ -36,6 +39,8 @@ public class ProfileEditActivity extends AppCompatActivity
 
     ProgressToggle mProgressToggle;
 
+    BroadcastReceiver mLogoutReceiver;
+
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -55,11 +60,19 @@ public class ProfileEditActivity extends AppCompatActivity
                 mAPIService, JodoAccount.getAccount(getApplicationContext()));
 
         mPresenter.start();
+
+        registerReceiver(mLogoutReceiver = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                finish();
+            }
+        }, JodoroidApplication.createLoggedOutIntentFilter());
     }
 
     @Override
     protected void onDestroy() {
         mPresenter.stop();
+        unregisterReceiver(mLogoutReceiver);
         super.onDestroy();
     }
 


### PR DESCRIPTION
Androidの設定からJodoroidアカウントが削除されたのを検知して，ログイン画面へ戻すようにします．
1. JodoApplicationで，onAccountsUpdatedイベントを受ける
   - Jodoroidアカウントが削除されていた場合，ACTION_LOGGED_OUTインテントをブロードキャスト
2. MainActivityなどログイン状態を仮定しているアクティビティは，ACTION_LOGGED_OUTインテントを受信して終了する
