### PR TITLE
MainActivityが作りなおされたときに，processIntentを呼ばない

### DIFF
--- a/app/src/main/java/com/pepabo/jodo/jodoroid/MainActivity.java
+++ b/app/src/main/java/com/pepabo/jodo/jodoroid/MainActivity.java
@@ -112,7 +112,9 @@ public class MainActivity extends AppCompatActivity
             }
         }, JodoroidApplication.createLoggedOutIntentFilter());
 
-        processIntent(getIntent());
+        if (savedInstanceState == null) {
+            processIntent(getIntent());
+        }
     }
 
     @Override


### PR DESCRIPTION
画面回転などでActivityが作りなおされたときにも`processIntent`メソッドを呼んでいたので，HomeFeedFragmentに戻ってしまう現象が起きていました．
