### PR TITLE
ResetPasswordのMVP化

### DIFF
--- a/app/app.iml
+++ b/app/app.iml
@@ -89,8 +89,6 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
-      <excludeFolder url="file://$MODULE_DIR$/build/reports" />
-      <excludeFolder url="file://$MODULE_DIR$/build/test-results" />
       <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
     <orderEntry type="jdk" jdkName="Android API 22 Platform" jdkType="Android SDK" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,7 +47,7 @@
             android:label="@string/title_activity_reset_password_request" >
         </activity>
         <activity
-            android:name=".ResetPassword"
+            android:name=".ResetPasswordActivity"
             android:label="@string/title_activity_reset_password" >
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />

--- a/app/src/main/java/com/pepabo/jodo/jodoroid/JodoroidApplication.java
+++ b/app/src/main/java/com/pepabo/jodo/jodoroid/JodoroidApplication.java
@@ -193,4 +193,11 @@ public class JodoroidApplication extends Application implements OnAccountsUpdate
     public static IntentFilter createLoggedOutIntentFilter() {
         return new IntentFilter(ACTION_LOGGED_OUT);
     }
+
+    public void doIntentTransition(Class cls) {
+        final Intent intent = new Intent(this, cls);
+        intent.setFlags(intent.FLAG_ACTIVITY_NEW_TASK);
+        startActivity(intent);
+    }
+
 }

--- a/app/src/main/java/com/pepabo/jodo/jodoroid/ResetPasswordActivity.java
+++ b/app/src/main/java/com/pepabo/jodo/jodoroid/ResetPasswordActivity.java
@@ -16,7 +16,7 @@ import butterknife.Bind;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 
-public class ResetPassword extends AppCompatActivity implements ResetPasswordView{
+public class ResetPasswordActivity extends AppCompatActivity implements ResetPasswordView{
 
     APIService mAPIService;
     ResetPasswordPresenter mPresenter;

--- a/app/src/main/java/com/pepabo/jodo/jodoroid/ResetPasswordPresenter.java
+++ b/app/src/main/java/com/pepabo/jodo/jodoroid/ResetPasswordPresenter.java
@@ -1,0 +1,98 @@
+package com.pepabo.jodo.jodoroid;
+
+import android.app.Activity;
+import android.content.Context;
+
+import com.pepabo.jodo.jodoroid.models.APIService;
+import com.pepabo.jodo.jodoroid.models.Session;
+
+import rx.Subscriber;
+import rx.Subscription;
+import rx.android.schedulers.AndroidSchedulers;
+import rx.subscriptions.Subscriptions;
+
+public class ResetPasswordPresenter {
+    ResetPasswordView mView;
+
+    PasswordValidator mPasswordValidator;
+
+    APIService mAPIService;
+    Subscription mSubscription = Subscriptions.unsubscribed();
+
+    public ResetPasswordPresenter(Context context, APIService apiService) {
+        this.mPasswordValidator = new PasswordValidator(context);
+
+        mAPIService = apiService;
+    }
+
+    public ResetPasswordView getView() {
+        return mView;
+    }
+
+    public void setView(ResetPasswordView view) {
+        mView = view;
+    }
+
+    public void submit() {
+        final ResetPasswordView view = mView;
+
+        if(view != null && mSubscription.isUnsubscribed()) {
+            final String token = view.getToken();
+            final String email = view.getEmail();
+            final String password = view.getPassword();
+
+            boolean cancel = false;
+
+            mPasswordValidator.validate(password);
+            if(mPasswordValidator.hasError()) {
+                view.setPasswordError(mPasswordValidator.getErrorMessage());
+                cancel = true;
+            }
+
+            if(!cancel) {
+                mSubscription = mAPIService.resetPassword(token, email, password)
+                        .observeOn(AndroidSchedulers.mainThread())
+                        .subscribe(new ResetPasswordSubscriber());
+            }
+        }
+    }
+
+    class ResetPasswordSubscriber extends Subscriber<Session> {
+        @Override
+        public void onStart() {
+            final ResetPasswordView view = getView();
+            if(view != null) {
+                view.showProgress(true);
+            }
+        }
+
+        @Override
+        public void onCompleted() {
+            final ResetPasswordView view = getView();
+            if(view != null) {
+                view.getJodoroidApplication().doIntentTransition(WelcomeActivity.class);
+                view.finish();
+            }
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            final ResetPasswordView view = getView();
+            if(view != null) {
+                view.showProgress(false);
+                view.onError(e);
+            }
+        }
+
+        @Override
+        public void onNext(Session session) {
+            final ResetPasswordView view = getView();
+            final Activity activity = view.getActivity();
+            final String email = view.getEmail();
+            if (view != null) {
+                JodoAccount.addAccount(activity, email, session);
+                view.onSuccess();
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/pepabo/jodo/jodoroid/ResetPasswordView.java
+++ b/app/src/main/java/com/pepabo/jodo/jodoroid/ResetPasswordView.java
@@ -1,0 +1,25 @@
+package com.pepabo.jodo.jodoroid;
+
+import android.app.Activity;
+
+public interface ResetPasswordView {
+    void setPasswordError(String message);
+
+    String getPassword();
+    void setPassword(String value);
+
+    String getToken();
+
+    String getEmail();
+
+    Activity getActivity();
+
+    JodoroidApplication getJodoroidApplication();
+
+    void showProgress(boolean show);
+
+    void onError(Throwable e);
+    void onSuccess();
+
+    void finish();
+}

--- a/app/src/main/res/layout/activity_reset_password.xml
+++ b/app/src/main/res/layout/activity_reset_password.xml
@@ -4,7 +4,7 @@
     android:layout_height="match_parent"
     android:gravity="center_horizontal"
     android:orientation="vertical"
-    tools:context="com.pepabo.jodo.jodoroid.ResetPassword">
+    tools:context="com.pepabo.jodo.jodoroid.ResetPasswordActivity">
 
     <ProgressBar
         android:id="@+id/progress"

--- a/app/src/main/res/layout/activity_reset_password.xml
+++ b/app/src/main/res/layout/activity_reset_password.xml
@@ -14,11 +14,11 @@
         android:visibility="gone" />
 
     <ScrollView
+        android:id="@+id/reset_password_form"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
         <LinearLayout
-            android:id="@+id/reset_password_form"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical"


### PR DESCRIPTION
# やったこと

AcitvityをViewとPresenterに分離しました。
パスワードリセットが完了した後にActivityを遷移させる部分は、
他のActivityをMVP化するときも使えるようにApplicationにメソッドとして用意しました。

@hanazuki @Joe-noh 確認お願いします。
