### PR TITLE
マイクロポストリストの余白を調整

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -3,6 +3,7 @@
     <option name="myName" value="Project Default" />
     <option name="myLocal" value="true" />
     <inspection_tool class="AndroidLintInvalidId" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="AndroidLintRtlHardcoded" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="LoggerInitializedWithForeignClass" enabled="false" level="WARNING" enabled_by_default="false">
       <option name="loggerClassName" value="org.apache.log4j.Logger,org.slf4j.LoggerFactory,org.apache.commons.logging.LogFactory,java.util.logging.Logger" />
       <option name="loggerFactoryMethodName" value="getLogger,getLogger,getLog,getLogger" />

--- a/app/app.iml
+++ b/app/app.iml
@@ -90,6 +90,8 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
+      <excludeFolder url="file://$MODULE_DIR$/build/reports" />
+      <excludeFolder url="file://$MODULE_DIR$/build/test-results" />
       <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
     <orderEntry type="jdk" jdkName="Android API 22 Platform" jdkType="Android SDK" />

--- a/app/src/main/res/layout/view_micropost.xml
+++ b/app/src/main/res/layout/view_micropost.xml
@@ -8,7 +8,8 @@
         android:id="@+id/avatar"
         android:layout_width="52dp"
         android:layout_height="52dp"
-        android:contentDescription="@string/description_user_avatar" />
+        android:contentDescription="@string/description_user_avatar"
+        android:layout_marginRight="3dp" />
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -18,22 +19,28 @@
         <TextView
             android:id="@+id/username"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            android:textStyle="bold" />
 
         <TextView
             android:id="@+id/content"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            android:layout_marginTop="1dp"
+            android:layout_marginBottom="1dp" />
 
         <ImageView
             android:id="@+id/picture"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:contentDescription="@string/description_attached_image" />
+            android:contentDescription="@string/description_attached_image"
+            android:layout_marginTop="2dp" />
 
         <TextView
             android:id="@+id/timestamp"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            android:gravity="right"
+            android:layout_marginRight="4dp" />
     </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/view_micropost.xml
+++ b/app/src/main/res/layout/view_micropost.xml
@@ -20,14 +20,16 @@
             android:id="@+id/username"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textStyle="bold" />
+            android:textStyle="bold"
+            android:layout_marginRight="2dp"
+            android:layout_marginTop="1dp" />
 
         <TextView
             android:id="@+id/content"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="1dp"
-            android:layout_marginBottom="1dp" />
+            android:layout_marginRight="2dp" />
 
         <ImageView
             android:id="@+id/picture"
@@ -40,7 +42,7 @@
             android:id="@+id/timestamp"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:gravity="right"
-            android:layout_marginRight="4dp" />
+            android:layout_marginRight="4dp"
+            android:gravity="end" />
     </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/view_micropost.xml
+++ b/app/src/main/res/layout/view_micropost.xml
@@ -6,8 +6,8 @@
 
     <ImageView
         android:id="@+id/avatar"
-        android:layout_width="52dp"
-        android:layout_height="52dp"
+        android:layout_width="54dp"
+        android:layout_height="54dp"
         android:contentDescription="@string/description_user_avatar"
         android:layout_marginRight="3dp" />
 


### PR DESCRIPTION
- アバターと文字がくっつきすぎていたのでアバターの右に余白を設けた
- 名前の上に余白を設けた
- 名前と本文をはっきり分けるため
  - 名前を太字にした
  - 本文の上下に余白を設けた
- 以下の理由で時間を右寄せにした
  - 全体が左寄せでｷﾞｭｯとしていたこと
  - 時間は別に目立たなくていいんじゃね
- 余白をつけて高さが変わったので、アバターサイズを2dp大きくした

| 調整前 | 調整後 |
| --- | --- |
| <img width="300px" src="https://cloud.githubusercontent.com/assets/2364702/9897205/b0d1bc8e-5c80-11e5-9ed1-458653feb8cb.png" /> | <img width="300px" src="https://cloud.githubusercontent.com/assets/2364702/9897602/5c8f710c-5c85-11e5-9a56-0bfc2f452fbf.png" /> |

文字サイズを小さくしたら見難かったので変えてません
