### PR TITLE
ユーザリストのレイアウトを調整

### DIFF
--- a/app/src/main/res/layout/view_user.xml
+++ b/app/src/main/res/layout/view_user.xml
@@ -1,22 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
-<GridLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="horizontal"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:columnCount="2"
-    android:rowCount="1">
+    android:layout_height="wrap_content"
+    android:layout_row="2"
+    android:layout_column="0">
 
     <ImageView
         android:id="@+id/imageView_user_avatar"
         android:layout_width="52dp"
         android:layout_height="52dp"
-        android:layout_column="0"
-        android:layout_row="0"
-        android:contentDescription="@string/description_user_avatar" />
+        android:contentDescription="@string/description_user_avatar"
+        android:layout_marginRight="3dp"
+        android:layout_marginEnd="3dp" />
 
     <TextView
         android:id="@+id/textView_user_name"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_column="1"
-        android:layout_row="0" />
-</GridLayout>
+        android:layout_marginRight="2dp"
+        android:layout_marginEnd="2dp"
+        android:layout_marginTop="1dp"
+        android:textStyle="bold" />
+
+</LinearLayout>


### PR DESCRIPTION
- アバターの右にマージン追加
- 名前を太字に
- GridLayoutをLinearLayoutに変更して名前が右に飛び出るのを修正

| 調整前 | 調整後 |
| --- | --- |
| <img width="300" src="https://cloud.githubusercontent.com/assets/2364702/9923335/b4722a00-5d2e-11e5-84af-710b8c254d2c.png" /> | <img width="300" src="https://cloud.githubusercontent.com/assets/2364702/9923339/be383246-5d2e-11e5-84ec-88f352d5502d.png" /> |
