### PR TITLE
スワイプによる再読み込みに失敗しても現在のViewを表示し続ける

### DIFF
--- a/app/src/main/java/com/pepabo/jodo/jodoroid/RefreshPresenter.java
+++ b/app/src/main/java/com/pepabo/jodo/jodoroid/RefreshPresenter.java
@@ -71,7 +71,6 @@ public abstract class RefreshPresenter<Model> {
         public void onStart() {
             final RefreshableView<Model> view = getView();
             if (view != null) {
-                view.setRefreshing(true);
             }
         }
 
@@ -102,6 +101,7 @@ public abstract class RefreshPresenter<Model> {
             final RefreshableView<Model> view = getView();
             if (view != null) {
                 view.onLoadError(e);
+                view.setRefreshing(false);
             }
         }
     }

--- a/app/src/main/java/com/pepabo/jodo/jodoroid/SwipeRefreshListFragment.java
+++ b/app/src/main/java/com/pepabo/jodo/jodoroid/SwipeRefreshListFragment.java
@@ -55,6 +55,7 @@ abstract public class SwipeRefreshListFragment<Model> extends ListFragment
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         mLayout = new FrameLayout(container.getContext());
         mSwipeRefreshLayout = new ListFragmentSwipeRefreshLayout(container.getContext());
+        mSwipeRefreshLayout.setColorSchemeResources(R.color.material_deep_teal_500);
 
         final View view = super.onCreateView(inflater, mSwipeRefreshLayout, savedInstanceState);
         mReloadView = inflater.inflate(R.layout.view_reload, mLayout, false);

--- a/app/src/main/java/com/pepabo/jodo/jodoroid/SwipeRefreshListFragment.java
+++ b/app/src/main/java/com/pepabo/jodo/jodoroid/SwipeRefreshListFragment.java
@@ -128,8 +128,10 @@ abstract public class SwipeRefreshListFragment<Model> extends ListFragment
     }
 
     public void onLoadError(Throwable e) {
-        mSwipeRefreshLayout.setVisibility(View.GONE);
-        mReloadView.setVisibility(View.VISIBLE);
+        if(getListAdapter() == null) {
+            mSwipeRefreshLayout.setVisibility(View.GONE);
+            mReloadView.setVisibility(View.VISIBLE);
+        }
     }
 
     abstract protected ArrayAdapter<Model> createAdapter(List<Model> list);


### PR DESCRIPTION
# やったこと

スワイプによる再読み込みに失敗したときにも
再読み込みボタンだけが表示されているViewへ切り替わってしまっていたので、
取得済みのデータを表示し続けるようにしました。

再読み込み中のプログレスバーの色をフローティングアクションボタンと同じにしました。

@hanazuki @Joe-noh 確認お願いします！
