### PR TITLE
タイムラインで添付画像が違うマイクロポストに表示される問題を修正

### DIFF
--- a/app/src/main/java/com/pepabo/jodo/jodoroid/MicropostsAdapter.java
+++ b/app/src/main/java/com/pepabo/jodo/jodoroid/MicropostsAdapter.java
@@ -50,6 +50,7 @@ class MicropostsAdapter extends ArrayAdapter<Micropost> {
                     .transform(new StarTransformation(micropost.isStarred())).into(holder.avatar);
             holder.username.setText(user.getName());
         } else {
+            mPicasso.cancelRequest(holder.avatar);
             holder.avatar.setImageDrawable(null);
             holder.username.setText("");
         }
@@ -73,6 +74,7 @@ class MicropostsAdapter extends ArrayAdapter<Micropost> {
                 }
             });
         } else {
+            mPicasso.cancelRequest(holder.picture);
             holder.picture.setImageDrawable(null);
         }
 


### PR DESCRIPTION
ListViewの要素を表示するためのビューはリサイクルされるのですが，高速にスクロールした場合など，Picassoが非同期に画像を読み込んでいる最中に別のマイクロポストの表示につかわれてしまうと，関係ないポストの画像が表示されてしまう問題がありました．

このパッチのように非同期リクエストをキャンセルすればいいはずですが，実際にうまくいってるかどうかはちゃんと確かめられていません．
