### PR TITLE
自分のUserProfile画面のバグを修正

### DIFF
--- a/app/src/main/java/com/pepabo/jodo/jodoroid/JodoAccount.java
+++ b/app/src/main/java/com/pepabo/jodo/jodoroid/JodoAccount.java
@@ -54,7 +54,6 @@ public class JodoAccount {
 
     public static boolean isMe(Context context, long userId) {
         final JodoAccount account = getAccount(context);
-        final AccountManager accountManager = AccountManager.get(context);
 
         return userId == account.getUserId();
     }

--- a/app/src/main/java/com/pepabo/jodo/jodoroid/MainActivity.java
+++ b/app/src/main/java/com/pepabo/jodo/jodoroid/MainActivity.java
@@ -255,7 +255,7 @@ public class MainActivity extends AppCompatActivity
     }
 
     private void showSelf() {
-        showFragment(UserProfileFragment.newInstance(UserProfilePresenter.SELF_ID));
+        showUser(JodoAccount.getAccount(getApplicationContext()).getUserId());
     }
 
     private void showFragment(Fragment fragment) {

--- a/app/src/main/java/com/pepabo/jodo/jodoroid/UserProfilePresenter.java
+++ b/app/src/main/java/com/pepabo/jodo/jodoroid/UserProfilePresenter.java
@@ -1,17 +1,11 @@
 package com.pepabo.jodo.jodoroid;
 
 import com.pepabo.jodo.jodoroid.models.APIService;
-import com.pepabo.jodo.jodoroid.models.Micropost;
 import com.pepabo.jodo.jodoroid.models.User;
 
-import java.util.List;
-
 import rx.Observable;
-import rx.Observer;
-import rx.android.schedulers.AndroidSchedulers;
 
 public class UserProfilePresenter extends RefreshPresenter<User> {
-    public static final long SELF_ID = -1;
     APIService mAPIService;
     long mUserId;
 
@@ -23,11 +17,7 @@ public class UserProfilePresenter extends RefreshPresenter<User> {
 
     @Override
     protected Observable<User> getObservable(int page) {
-        if(mUserId == SELF_ID) {
-            return mAPIService.fetchMe(page);
-        } else {
-            return mAPIService.fetchUser(mUserId, page);
-        }
+        return mAPIService.fetchUser(mUserId, page);
     }
 
     @Override


### PR DESCRIPTION
ドロワーの自分のアバターをクリックして，自分のプロフィール画面にゆくと，
そこから自分のfollower/followingの画面に遷移できないバグです．

:bow:
#117 でMainActivityで自分のユーザ情報を読み込み終わる前に，

ドロワーのアバターをタップした時にも自分のプロフィール画面に遷移できるよう
-1を自分のuserIdとして使おうとしていたけれど，
コードの他の部分で-1はuserId未設定時の値として使っていた．
